### PR TITLE
feat: calling the Graph API to get a list of call records

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -14,6 +14,12 @@
       "termsOfUseUrl": "",
       "mpnId": "Undefined-1.14.0"
     },
+    "webApiPermissionRequests": [
+      {
+        "resource": "Microsoft Graph",
+        "scope": "CallRecords.Read.All"
+      }
+    ],
     "metadata": {
       "shortDescription": {
         "default": "ms-graph-front-end description"

--- a/config/serve.json
+++ b/config/serve.json
@@ -2,5 +2,5 @@
   "$schema": "https://developer.microsoft.com/json-schemas/core-build/serve.schema.json",
   "port": 4321,
   "https": true,
-  "initialPage": "https://enter-your-SharePoint-site/_layouts/workbench.aspx"
+  "initialPage": "https://2406cq.sharepoint.com/sites/Mark8ProjectTeam/_layouts/workbench.aspx"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,6 +1755,11 @@
         "isomorphic-fetch": "^2.2.1"
       }
     },
+    "@microsoft/microsoft-graph-types": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.16.0.tgz",
+      "integrity": "sha512-Qvxv9mpXb/F4xlESEkSLjREHj3dAixTkH3LVO6Ct6sllc5RWrQxPxaSGqW9IpcLU6jI49f2XNSGLotVef3Irdg=="
+    },
     "@microsoft/office-ui-fabric-react-bundle": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "office-ui-fabric-react": "7.174.1",
+    "@microsoft/microsoft-graph-types": "^2.16.0",
     "@microsoft/sp-core-library": "1.14.0",
+    "@microsoft/sp-lodash-subset": "1.14.0",
+    "@microsoft/sp-office-ui-fabric-core": "1.14.0",
     "@microsoft/sp-property-pane": "1.14.0",
     "@microsoft/sp-webpart-base": "1.14.0",
-    "@microsoft/sp-lodash-subset": "1.14.0",
-    "@microsoft/sp-office-ui-fabric-core": "1.14.0"
+    "office-ui-fabric-react": "7.174.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1"
   },
   "devDependencies": {
     "@types/react": "16.9.51",


### PR DESCRIPTION
Calling the Graph API to get callRecords and looping through the data to show a list of the last 5 calls, grouped in decending endDateTime.

Added scope and permissions in the package-solution.json.

Updated the serve.json to test the webpart.

Added the '@microsoft/microsoft-graph-types' dependency.



